### PR TITLE
Removing GPL license header from files.

### DIFF
--- a/app/src/androidTest/java/org/codroid/body/LogTest.java
+++ b/app/src/androidTest/java/org/codroid/body/LogTest.java
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.body;
 
 

--- a/app/src/main/java/org/codroid/body/widget/BottomPanel.java
+++ b/app/src/main/java/org/codroid/body/widget/BottomPanel.java
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.body.widget;
 
 import android.content.Context;

--- a/app/src/main/java/org/codroid/body/widget/Divider.java
+++ b/app/src/main/java/org/codroid/body/widget/Divider.java
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.body.widget;
 
 import android.content.Context;

--- a/app/src/main/kotlin/org/codroid/body/Codroid.kt
+++ b/app/src/main/kotlin/org/codroid/body/Codroid.kt
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.body
 
 import android.app.Application

--- a/app/src/main/kotlin/org/codroid/body/UIUtils.kt
+++ b/app/src/main/kotlin/org/codroid/body/UIUtils.kt
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.body
 
 import android.content.Context

--- a/app/src/main/kotlin/org/codroid/body/ui/ItemEntities.kt
+++ b/app/src/main/kotlin/org/codroid/body/ui/ItemEntities.kt
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.body.ui
 
 import android.graphics.Bitmap

--- a/app/src/main/kotlin/org/codroid/body/ui/Response.kt
+++ b/app/src/main/kotlin/org/codroid/body/ui/Response.kt
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.body.ui
 
 class Response<T> (state: Int) {

--- a/app/src/main/kotlin/org/codroid/body/ui/addonmanager/AddonManagerActivity.kt
+++ b/app/src/main/kotlin/org/codroid/body/ui/addonmanager/AddonManagerActivity.kt
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.body.ui.addonmanager
 
 import android.os.Bundle

--- a/app/src/main/kotlin/org/codroid/body/ui/addonmanager/AddonManagerViewModel.kt
+++ b/app/src/main/kotlin/org/codroid/body/ui/addonmanager/AddonManagerViewModel.kt
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.body.ui.addonmanager
 
 import android.net.Uri

--- a/app/src/main/kotlin/org/codroid/body/ui/addonmanager/AddonRecyclerAdapter.kt
+++ b/app/src/main/kotlin/org/codroid/body/ui/addonmanager/AddonRecyclerAdapter.kt
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.body.ui.addonmanager
 
 import android.content.Context

--- a/app/src/main/kotlin/org/codroid/body/ui/dirtree/DirTreeAdapter.kt
+++ b/app/src/main/kotlin/org/codroid/body/ui/dirtree/DirTreeAdapter.kt
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.body.ui.dirtree
 
 import android.content.Context

--- a/app/src/main/kotlin/org/codroid/body/ui/dirtree/FileTreeNode.kt
+++ b/app/src/main/kotlin/org/codroid/body/ui/dirtree/FileTreeNode.kt
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.body.ui.dirtree
 
 import java.io.File

--- a/app/src/main/kotlin/org/codroid/body/ui/main/EditorWindowAdapter.kt
+++ b/app/src/main/kotlin/org/codroid/body/ui/main/EditorWindowAdapter.kt
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.body.ui.main
 
 import androidx.fragment.app.Fragment

--- a/app/src/main/kotlin/org/codroid/body/ui/main/EditorWindowFragment.kt
+++ b/app/src/main/kotlin/org/codroid/body/ui/main/EditorWindowFragment.kt
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.body.ui.main
 
 import android.os.Bundle

--- a/app/src/main/kotlin/org/codroid/body/ui/main/MainActivity.kt
+++ b/app/src/main/kotlin/org/codroid/body/ui/main/MainActivity.kt
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.body.ui.main
 
 import android.Manifest

--- a/app/src/main/kotlin/org/codroid/body/ui/main/MainViewModel.kt
+++ b/app/src/main/kotlin/org/codroid/body/ui/main/MainViewModel.kt
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.body.ui.main
 
 import androidx.lifecycle.ViewModel

--- a/app/src/main/kotlin/org/codroid/body/ui/main/WindowTabAdapter.kt
+++ b/app/src/main/kotlin/org/codroid/body/ui/main/WindowTabAdapter.kt
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.body.ui.main
 
 import android.content.Context

--- a/app/src/main/kotlin/org/codroid/body/ui/utils/CommonFuns.kt
+++ b/app/src/main/kotlin/org/codroid/body/ui/utils/CommonFuns.kt
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.body.ui.utils
 
 import android.content.Context

--- a/app/src/main/kotlin/org/codroid/body/ui/utils/EditorWindowHelper.kt
+++ b/app/src/main/kotlin/org/codroid/body/ui/utils/EditorWindowHelper.kt
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.body.ui.utils
 
 import android.view.View

--- a/app/src/main/kotlin/org/codroid/body/ui/utils/PermissionUtils.kt
+++ b/app/src/main/kotlin/org/codroid/body/ui/utils/PermissionUtils.kt
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.body.ui.utils
 
 import android.Manifest

--- a/app/src/main/kotlin/org/codroid/body/widgets/CodroidEditor.kt
+++ b/app/src/main/kotlin/org/codroid/body/widgets/CodroidEditor.kt
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.body.widgets
 
 import android.content.Context

--- a/app/src/main/kotlin/org/codroid/body/widgets/DirTreeItemView.kt
+++ b/app/src/main/kotlin/org/codroid/body/widgets/DirTreeItemView.kt
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.body.widgets
 
 import android.content.Context

--- a/app/src/main/kotlin/org/codroid/body/widgets/EditorDelegate.kt
+++ b/app/src/main/kotlin/org/codroid/body/widgets/EditorDelegate.kt
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2022 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.body.widgets
 
 import android.annotation.SuppressLint

--- a/app/src/main/kotlin/org/codroid/body/widgets/WindowTab.kt
+++ b/app/src/main/kotlin/org/codroid/body/widgets/WindowTab.kt
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.body.widgets
 
 import android.animation.ValueAnimator

--- a/app/src/main/res/animator/appbar_elevation.xml
+++ b/app/src/main/res/animator/appbar_elevation.xml
@@ -1,21 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?><!--
-  ~     Copyright (c) 2021 Zachary. All rights reserved.
-  ~
-  ~     This file is part of Codroid.
-  ~
-  ~     Codroid is free software: you can redistribute it and/or modify
-  ~     it under the terms of the GNU General Public License as published by
-  ~     the Free Software Foundation, either version 3 of the License, or
-  ~     (at your option) any later version.
-  ~
-  ~     Codroid is distributed in the hope that it will be useful,
-  ~     but WITHOUT ANY WARRANTY; without even the implied warranty of
-  ~     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  ~     GNU General Public License for more details.
-  ~
-  ~     You should have received a copy of the GNU General Public License
-  ~     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
-  -->
+<?xml version="1.0" encoding="utf-8"?>
 <selector xmlns:android="http://schemas.android.com/apk/res/android">
     <item>
         <objectAnimator

--- a/app/src/main/res/drawable/ic_baseline_expand_more_24.xml
+++ b/app/src/main/res/drawable/ic_baseline_expand_more_24.xml
@@ -1,22 +1,3 @@
-<!--
-  ~     Copyright (c) 2021 Zachary. All rights reserved.
-  ~
-  ~     This file is part of Codroid.
-  ~
-  ~     Codroid is free software: you can redistribute it and/or modify
-  ~     it under the terms of the GNU General Public License as published by
-  ~     the Free Software Foundation, either version 3 of the License, or
-  ~     (at your option) any later version.
-  ~
-  ~     Codroid is distributed in the hope that it will be useful,
-  ~     but WITHOUT ANY WARRANTY; without even the implied warranty of
-  ~     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  ~     GNU General Public License for more details.
-  ~
-  ~     You should have received a copy of the GNU General Public License
-  ~     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
-  -->
-
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
     android:height="24dp"

--- a/app/src/main/res/drawable/ic_twotone_description_24.xml
+++ b/app/src/main/res/drawable/ic_twotone_description_24.xml
@@ -1,21 +1,4 @@
-<!--
-  ~     Copyright (c) 2021 Zachary. All rights reserved.
-  ~
-  ~     This file is part of Codroid.
-  ~
-  ~     Codroid is free software: you can redistribute it and/or modify
-  ~     it under the terms of the GNU General Public License as published by
-  ~     the Free Software Foundation, either version 3 of the License, or
-  ~     (at your option) any later version.
-  ~
-  ~     Codroid is distributed in the hope that it will be useful,
-  ~     but WITHOUT ANY WARRANTY; without even the implied warranty of
-  ~     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  ~     GNU General Public License for more details.
-  ~
-  ~     You should have received a copy of the GNU General Public License
-  ~     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
-  -->
+
 
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"

--- a/app/src/main/res/layout/activity_addon_manager.xml
+++ b/app/src/main/res/layout/activity_addon_manager.xml
@@ -1,21 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?><!--
-  ~     Copyright (c) 2021 Zachary. All rights reserved.
-  ~
-  ~     This file is part of Codroid.
-  ~
-  ~     Codroid is free software: you can redistribute it and/or modify
-  ~     it under the terms of the GNU General Public License as published by
-  ~     the Free Software Foundation, either version 3 of the License, or
-  ~     (at your option) any later version.
-  ~
-  ~     Codroid is distributed in the hope that it will be useful,
-  ~     but WITHOUT ANY WARRANTY; without even the implied warranty of
-  ~     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  ~     GNU General Public License for more details.
-  ~
-  ~     You should have received a copy of the GNU General Public License
-  ~     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
-  -->
+<?xml version="1.0" encoding="utf-8"?>
 <androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,21 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?><!--
-  ~     Copyright (c) 2021 Zachary. All rights reserved.
-  ~
-  ~     This file is part of Codroid.
-  ~
-  ~     Codroid is free software: you can redistribute it and/or modify
-  ~     it under the terms of the GNU General Public License as published by
-  ~     the Free Software Foundation, either version 3 of the License, or
-  ~     (at your option) any later version.
-  ~
-  ~     Codroid is distributed in the hope that it will be useful,
-  ~     but WITHOUT ANY WARRANTY; without even the implied warranty of
-  ~     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  ~     GNU General Public License for more details.
-  ~
-  ~     You should have received a copy of the GNU General Public License
-  ~     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
-  -->
+<?xml version="1.0" encoding="utf-8"?>
 
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"

--- a/app/src/main/res/layout/fragment_editor_window.xml
+++ b/app/src/main/res/layout/fragment_editor_window.xml
@@ -1,21 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?><!--
-  ~     Copyright (c) 2021 Zachary. All rights reserved.
-  ~
-  ~     This file is part of Codroid.
-  ~
-  ~     Codroid is free software: you can redistribute it and/or modify
-  ~     it under the terms of the GNU General Public License as published by
-  ~     the Free Software Foundation, either version 3 of the License, or
-  ~     (at your option) any later version.
-  ~
-  ~     Codroid is distributed in the hope that it will be useful,
-  ~     but WITHOUT ANY WARRANTY; without even the implied warranty of
-  ~     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  ~     GNU General Public License for more details.
-  ~
-  ~     You should have received a copy of the GNU General Public License
-  ~     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
-  -->
+<?xml version="1.0" encoding="utf-8"?>
 
 <org.codroid.editor.UnrestrainedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"

--- a/app/src/main/res/layout/item_addon.xml
+++ b/app/src/main/res/layout/item_addon.xml
@@ -1,21 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?><!--
-  ~     Copyright (c) 2021 Zachary. All rights reserved.
-  ~
-  ~     This file is part of Codroid.
-  ~
-  ~     Codroid is free software: you can redistribute it and/or modify
-  ~     it under the terms of the GNU General Public License as published by
-  ~     the Free Software Foundation, either version 3 of the License, or
-  ~     (at your option) any later version.
-  ~
-  ~     Codroid is distributed in the hope that it will be useful,
-  ~     but WITHOUT ANY WARRANTY; without even the implied warranty of
-  ~     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  ~     GNU General Public License for more details.
-  ~
-  ~     You should have received a copy of the GNU General Public License
-  ~     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
-  -->
+<?xml version="1.0" encoding="utf-8"?>
 <layout>
 
     <data>

--- a/app/src/main/res/layout/item_dir_tree.xml
+++ b/app/src/main/res/layout/item_dir_tree.xml
@@ -1,21 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?><!--
-  ~     Copyright (c) 2021 Zachary. All rights reserved.
-  ~
-  ~     This file is part of Codroid.
-  ~
-  ~     Codroid is free software: you can redistribute it and/or modify
-  ~     it under the terms of the GNU General Public License as published by
-  ~     the Free Software Foundation, either version 3 of the License, or
-  ~     (at your option) any later version.
-  ~
-  ~     Codroid is distributed in the hope that it will be useful,
-  ~     but WITHOUT ANY WARRANTY; without even the implied warranty of
-  ~     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  ~     GNU General Public License for more details.
-  ~
-  ~     You should have received a copy of the GNU General Public License
-  ~     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
-  -->
+<?xml version="1.0" encoding="utf-8"?>
 
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">

--- a/app/src/main/res/layout/item_window_tab.xml
+++ b/app/src/main/res/layout/item_window_tab.xml
@@ -1,21 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?><!--
-  ~     Copyright (c) 2021 Zachary. All rights reserved.
-  ~
-  ~     This file is part of Codroid.
-  ~
-  ~     Codroid is free software: you can redistribute it and/or modify
-  ~     it under the terms of the GNU General Public License as published by
-  ~     the Free Software Foundation, either version 3 of the License, or
-  ~     (at your option) any later version.
-  ~
-  ~     Codroid is distributed in the hope that it will be useful,
-  ~     but WITHOUT ANY WARRANTY; without even the implied warranty of
-  ~     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  ~     GNU General Public License for more details.
-  ~
-  ~     You should have received a copy of the GNU General Public License
-  ~     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
-  -->
+<?xml version="1.0" encoding="utf-8"?>
 <layout xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <data>

--- a/app/src/main/res/layout/suggestion_window.xml
+++ b/app/src/main/res/layout/suggestion_window.xml
@@ -1,21 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?><!--
-  ~     Copyright (c) 2021 Zachary. All rights reserved.
-  ~
-  ~     This file is part of Codroid.
-  ~
-  ~     Codroid is free software: you can redistribute it and/or modify
-  ~     it under the terms of the GNU General Public License as published by
-  ~     the Free Software Foundation, either version 3 of the License, or
-  ~     (at your option) any later version.
-  ~
-  ~     Codroid is distributed in the hope that it will be useful,
-  ~     but WITHOUT ANY WARRANTY; without even the implied warranty of
-  ~     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  ~     GNU General Public License for more details.
-  ~
-  ~     You should have received a copy of the GNU General Public License
-  ~     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
-  -->
+<?xml version="1.0" encoding="utf-8"?>
 
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"

--- a/app/src/main/res/menu/main_tool_bar_menu.xml
+++ b/app/src/main/res/menu/main_tool_bar_menu.xml
@@ -1,21 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?><!--
-  ~     Copyright (c) 2021 Zachary. All rights reserved.
-  ~
-  ~     This file is part of Codroid.
-  ~
-  ~     Codroid is free software: you can redistribute it and/or modify
-  ~     it under the terms of the GNU General Public License as published by
-  ~     the Free Software Foundation, either version 3 of the License, or
-  ~     (at your option) any later version.
-  ~
-  ~     Codroid is distributed in the hope that it will be useful,
-  ~     but WITHOUT ANY WARRANTY; without even the implied warranty of
-  ~     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  ~     GNU General Public License for more details.
-  ~
-  ~     You should have received a copy of the GNU General Public License
-  ~     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
-  -->
+<?xml version="1.0" encoding="utf-8"?>
 
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -1,21 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?><!--
-  ~     Copyright (c) 2021 Zachary. All rights reserved.
-  ~
-  ~     This file is part of Codroid.
-  ~
-  ~     Codroid is free software: you can redistribute it and/or modify
-  ~     it under the terms of the GNU General Public License as published by
-  ~     the Free Software Foundation, either version 3 of the License, or
-  ~     (at your option) any later version.
-  ~
-  ~     Codroid is distributed in the hope that it will be useful,
-  ~     but WITHOUT ANY WARRANTY; without even the implied warranty of
-  ~     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  ~     GNU General Public License for more details.
-  ~
-  ~     You should have received a copy of the GNU General Public License
-  ~     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
-  -->
+<?xml version="1.0" encoding="utf-8"?>
 <resources>
     <declare-styleable name="Divider">
         <attr name="backgroundColor" format="color" />

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,21 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?><!--
-  ~     Copyright (c) 2021 Zachary. All rights reserved.
-  ~
-  ~     This file is part of Codroid.
-  ~
-  ~     Codroid is free software: you can redistribute it and/or modify
-  ~     it under the terms of the GNU General Public License as published by
-  ~     the Free Software Foundation, either version 3 of the License, or
-  ~     (at your option) any later version.
-  ~
-  ~     Codroid is distributed in the hope that it will be useful,
-  ~     but WITHOUT ANY WARRANTY; without even the implied warranty of
-  ~     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  ~     GNU General Public License for more details.
-  ~
-  ~     You should have received a copy of the GNU General Public License
-  ~     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
-  -->
+<?xml version="1.0" encoding="utf-8"?>
 
 <resources>
     <dimen name="dp_4">4dp</dimen>

--- a/app/src/main/res/xml/backup_descriptor.xml
+++ b/app/src/main/res/xml/backup_descriptor.xml
@@ -1,22 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-  ~     Copyright (c) 2021 Zachary. All rights reserved.
-  ~
-  ~     This file is part of Codroid.
-  ~
-  ~     Codroid is free software: you can redistribute it and/or modify
-  ~     it under the terms of the GNU General Public License as published by
-  ~     the Free Software Foundation, either version 3 of the License, or
-  ~     (at your option) any later version.
-  ~
-  ~     Codroid is distributed in the hope that it will be useful,
-  ~     but WITHOUT ANY WARRANTY; without even the implied warranty of
-  ~     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  ~     GNU General Public License for more details.
-  ~
-  ~     You should have received a copy of the GNU General Public License
-  ~     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
-  -->
+
 
 <full-backup-content>
     <!-- Exclude specific shared preferences that contain GCM registration Id -->

--- a/editor/build.gradle
+++ b/editor/build.gradle
@@ -1,23 +1,4 @@
 
-/*
- *     Copyright (c) 2022 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 plugins {
     id 'com.android.library'
     id 'org.jetbrains.kotlin.android'

--- a/editor/src/androidTest/java/org/codroid/editor/ExampleInstrumentedTest.kt
+++ b/editor/src/androidTest/java/org/codroid/editor/ExampleInstrumentedTest.kt
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2022 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.editor
 
 import androidx.test.platform.app.InstrumentationRegistry

--- a/editor/src/main/AndroidManifest.xml
+++ b/editor/src/main/AndroidManifest.xml
@@ -1,23 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-  ~     Copyright (c) 2022 Zachary. All rights reserved.
-  ~
-  ~     This file is part of Codroid.
-  ~
-  ~     Codroid is free software: you can redistribute it and/or modify
-  ~     it under the terms of the GNU General Public License as published by
-  ~     the Free Software Foundation, either version 3 of the License, or
-  ~     (at your option) any later version.
-  ~
-  ~     Codroid is distributed in the hope that it will be useful,
-  ~     but WITHOUT ANY WARRANTY; without even the implied warranty of
-  ~     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  ~     GNU General Public License for more details.
-  ~
-  ~     You should have received a copy of the GNU General Public License
-  ~     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
-  -->
-
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
 </manifest>

--- a/editor/src/main/java/org/codroid/editor/CodroidEditor.kt
+++ b/editor/src/main/java/org/codroid/editor/CodroidEditor.kt
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2022 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.editor
 
 import android.annotation.SuppressLint

--- a/editor/src/main/java/org/codroid/editor/EditContent.kt
+++ b/editor/src/main/java/org/codroid/editor/EditContent.kt
@@ -1,23 +1,3 @@
-/*
- *      Copyright (c) 2022 Zachary. All rights reserved.
- *
- *      This file is part of Codroid.
- *
- *      Codroid is free software: you can redistribute it and/or modify
- *      it under the terms of the GNU General Public License as published by
- *      the Free Software Foundation, either version 3 of the License, or
- *      (at your option) any later version.
- *
- *      Codroid is distributed in the hope that it will be useful,
- *       but WITHOUT ANY WARRANTY; without even the implied warranty of
- *      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *      GNU General Public License for more details.
- *
- *      You should have received a copy of the GNU General Public License
- *      along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- *
- */
-
 package org.codroid.editor
 
 import android.graphics.Color

--- a/editor/src/main/java/org/codroid/editor/UnrestrainedScrollView.kt
+++ b/editor/src/main/java/org/codroid/editor/UnrestrainedScrollView.kt
@@ -1,23 +1,3 @@
-/*
- *      Copyright (c) 2022 Zachary. All rights reserved.
- *
- *      This file is part of Codroid.
- *
- *      Codroid is free software: you can redistribute it and/or modify
- *      it under the terms of the GNU General Public License as published by
- *      the Free Software Foundation, either version 3 of the License, or
- *      (at your option) any later version.
- *
- *      Codroid is distributed in the hope that it will be useful,
- *       but WITHOUT ANY WARRANTY; without even the implied warranty of
- *      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *      GNU General Public License for more details.
- *
- *      You should have received a copy of the GNU General Public License
- *      along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- *
- */
-
 
 package org.codroid.editor
 

--- a/editor/src/main/java/org/codroid/editor/algorithm/TextSequence.kt
+++ b/editor/src/main/java/org/codroid/editor/algorithm/TextSequence.kt
@@ -1,23 +1,3 @@
-/*
- *      Copyright (c) 2022 Zachary. All rights reserved.
- *
- *      This file is part of Codroid.
- *
- *      Codroid is free software: you can redistribute it and/or modify
- *      it under the terms of the GNU General Public License as published by
- *      the Free Software Foundation, either version 3 of the License, or
- *      (at your option) any later version.
- *
- *      Codroid is distributed in the hope that it will be useful,
- *       but WITHOUT ANY WARRANTY; without even the implied warranty of
- *      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *      GNU General Public License for more details.
- *
- *      You should have received a copy of the GNU General Public License
- *      along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- *
- */
-
 package org.codroid.editor.algorithm
 
 import org.codroid.editor.utils.IntPair

--- a/editor/src/main/java/org/codroid/editor/algorithm/exceptions/TooLongPiecesException.kt
+++ b/editor/src/main/java/org/codroid/editor/algorithm/exceptions/TooLongPiecesException.kt
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2022 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.editor.algorithm.exceptions
 
 class TooLongPiecesException : Exception() {

--- a/editor/src/main/java/org/codroid/editor/algorithm/linearr/LineArray.kt
+++ b/editor/src/main/java/org/codroid/editor/algorithm/linearr/LineArray.kt
@@ -1,23 +1,3 @@
-/*
- *      Copyright (c) 2022 Zachary. All rights reserved.
- *
- *      This file is part of Codroid.
- *
- *      Codroid is free software: you can redistribute it and/or modify
- *      it under the terms of the GNU General Public License as published by
- *      the Free Software Foundation, either version 3 of the License, or
- *      (at your option) any later version.
- *
- *      Codroid is distributed in the hope that it will be useful,
- *       but WITHOUT ANY WARRANTY; without even the implied warranty of
- *      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *      GNU General Public License for more details.
- *
- *      You should have received a copy of the GNU General Public License
- *      along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- *
- */
-
 
 package org.codroid.editor.algorithm.linearr
 

--- a/editor/src/main/java/org/codroid/editor/decoration/BackgroundSpan.kt
+++ b/editor/src/main/java/org/codroid/editor/decoration/BackgroundSpan.kt
@@ -1,23 +1,3 @@
-/*
- *      Copyright (c) 2022 Zachary. All rights reserved.
- *
- *      This file is part of Codroid.
- *
- *      Codroid is free software: you can redistribute it and/or modify
- *      it under the terms of the GNU General Public License as published by
- *      the Free Software Foundation, either version 3 of the License, or
- *      (at your option) any later version.
- *
- *      Codroid is distributed in the hope that it will be useful,
- *       but WITHOUT ANY WARRANTY; without even the implied warranty of
- *      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *      GNU General Public License for more details.
- *
- *      You should have received a copy of the GNU General Public License
- *      along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- *
- */
-
 package org.codroid.editor.decoration
 
 interface BackgroundSpan : SpanDecoration, Drawable {

--- a/editor/src/main/java/org/codroid/editor/decoration/CharacterSpan.kt
+++ b/editor/src/main/java/org/codroid/editor/decoration/CharacterSpan.kt
@@ -1,23 +1,3 @@
-/*
- *      Copyright (c) 2022 Zachary. All rights reserved.
- *
- *      This file is part of Codroid.
- *
- *      Codroid is free software: you can redistribute it and/or modify
- *      it under the terms of the GNU General Public License as published by
- *      the Free Software Foundation, either version 3 of the License, or
- *      (at your option) any later version.
- *
- *      Codroid is distributed in the hope that it will be useful,
- *       but WITHOUT ANY WARRANTY; without even the implied warranty of
- *      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *      GNU General Public License for more details.
- *
- *      You should have received a copy of the GNU General Public License
- *      along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- *
- */
-
 package org.codroid.editor.decoration
 
 import android.graphics.Canvas

--- a/editor/src/main/java/org/codroid/editor/decoration/Decoration.kt
+++ b/editor/src/main/java/org/codroid/editor/decoration/Decoration.kt
@@ -1,23 +1,3 @@
-/*
- *      Copyright (c) 2022 Zachary. All rights reserved.
- *
- *      This file is part of Codroid.
- *
- *      Codroid is free software: you can redistribute it and/or modify
- *      it under the terms of the GNU General Public License as published by
- *      the Free Software Foundation, either version 3 of the License, or
- *      (at your option) any later version.
- *
- *      Codroid is distributed in the hope that it will be useful,
- *       but WITHOUT ANY WARRANTY; without even the implied warranty of
- *      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *      GNU General Public License for more details.
- *
- *      You should have received a copy of the GNU General Public License
- *      along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- *
- */
-
 package org.codroid.editor.decoration
 
 import android.graphics.Canvas

--- a/editor/src/main/java/org/codroid/editor/decoration/Decorator.kt
+++ b/editor/src/main/java/org/codroid/editor/decoration/Decorator.kt
@@ -1,23 +1,3 @@
-/*
- *      Copyright (c) 2022 Zachary. All rights reserved.
- *
- *      This file is part of Codroid.
- *
- *      Codroid is free software: you can redistribute it and/or modify
- *      it under the terms of the GNU General Public License as published by
- *      the Free Software Foundation, either version 3 of the License, or
- *      (at your option) any later version.
- *
- *      Codroid is distributed in the hope that it will be useful,
- *       but WITHOUT ANY WARRANTY; without even the implied warranty of
- *      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *      GNU General Public License for more details.
- *
- *      You should have received a copy of the GNU General Public License
- *      along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- *
- */
-
 package org.codroid.editor.decoration
 
 import android.graphics.Color

--- a/editor/src/main/java/org/codroid/editor/decoration/ForegroundSpan.kt
+++ b/editor/src/main/java/org/codroid/editor/decoration/ForegroundSpan.kt
@@ -1,23 +1,3 @@
-/*
- *      Copyright (c) 2022 Zachary. All rights reserved.
- *
- *      This file is part of Codroid.
- *
- *      Codroid is free software: you can redistribute it and/or modify
- *      it under the terms of the GNU General Public License as published by
- *      the Free Software Foundation, either version 3 of the License, or
- *      (at your option) any later version.
- *
- *      Codroid is distributed in the hope that it will be useful,
- *       but WITHOUT ANY WARRANTY; without even the implied warranty of
- *      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *      GNU General Public License for more details.
- *
- *      You should have received a copy of the GNU General Public License
- *      along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- *
- */
-
 package org.codroid.editor.decoration
 
 import android.graphics.Canvas

--- a/editor/src/main/java/org/codroid/editor/decoration/ReplacementSpan.kt
+++ b/editor/src/main/java/org/codroid/editor/decoration/ReplacementSpan.kt
@@ -1,23 +1,3 @@
-/*
- *      Copyright (c) 2022 Zachary. All rights reserved.
- *
- *      This file is part of Codroid.
- *
- *      Codroid is free software: you can redistribute it and/or modify
- *      it under the terms of the GNU General Public License as published by
- *      the Free Software Foundation, either version 3 of the License, or
- *      (at your option) any later version.
- *
- *      Codroid is distributed in the hope that it will be useful,
- *       but WITHOUT ANY WARRANTY; without even the implied warranty of
- *      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *      GNU General Public License for more details.
- *
- *      You should have received a copy of the GNU General Public License
- *      along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- *
- */
-
 package org.codroid.editor.decoration
 
 import android.graphics.Canvas

--- a/editor/src/main/java/org/codroid/editor/utils/Utils.kt
+++ b/editor/src/main/java/org/codroid/editor/utils/Utils.kt
@@ -1,23 +1,3 @@
-/*
- *      Copyright (c) 2022 Zachary. All rights reserved.
- *
- *      This file is part of Codroid.
- *
- *      Codroid is free software: you can redistribute it and/or modify
- *      it under the terms of the GNU General Public License as published by
- *      the Free Software Foundation, either version 3 of the License, or
- *      (at your option) any later version.
- *
- *      Codroid is distributed in the hope that it will be useful,
- *       but WITHOUT ANY WARRANTY; without even the implied warranty of
- *      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *      GNU General Public License for more details.
- *
- *      You should have received a copy of the GNU General Public License
- *      along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- *
- */
-
 package org.codroid.editor.utils
 
 import org.codroid.editor.decoration.*

--- a/editor/src/test/java/org/codroid/editor/EditContentTest.kt
+++ b/editor/src/test/java/org/codroid/editor/EditContentTest.kt
@@ -1,23 +1,3 @@
-/*
- *      Copyright (c) 2022 Zachary. All rights reserved.
- *
- *      This file is part of Codroid.
- *
- *      Codroid is free software: you can redistribute it and/or modify
- *      it under the terms of the GNU General Public License as published by
- *      the Free Software Foundation, either version 3 of the License, or
- *      (at your option) any later version.
- *
- *      Codroid is distributed in the hope that it will be useful,
- *       but WITHOUT ANY WARRANTY; without even the implied warranty of
- *      MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *      GNU General Public License for more details.
- *
- *      You should have received a copy of the GNU General Public License
- *      along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- *
- */
-
 package org.codroid.editor
 
 class EditContentTest {

--- a/editor/src/test/java/org/codroid/editor/RopeTest.kt
+++ b/editor/src/test/java/org/codroid/editor/RopeTest.kt
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2022 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.editor
 
 import org.junit.Test

--- a/interfaces/build.gradle
+++ b/interfaces/build.gradle
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 plugins {
     id 'com.android.library'
     id 'kotlin-android'

--- a/interfaces/src/main/AndroidManifest.xml
+++ b/interfaces/src/main/AndroidManifest.xml
@@ -1,22 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!--
-  ~     Copyright (c) 2021 Zachary. All rights reserved.
-  ~
-  ~     This file is part of Codroid.
-  ~
-  ~     Codroid is free software: you can redistribute it and/or modify
-  ~     it under the terms of the GNU General Public License as published by
-  ~     the Free Software Foundation, either version 3 of the License, or
-  ~     (at your option) any later version.
-  ~
-  ~     Codroid is distributed in the hope that it will be useful,
-  ~     but WITHOUT ANY WARRANTY; without even the implied warranty of
-  ~     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  ~     GNU General Public License for more details.
-  ~
-  ~     You should have received a copy of the GNU General Public License
-  ~     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
-  -->
+
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 

--- a/interfaces/src/main/java/org/codroid/interfaces/Attachment.java
+++ b/interfaces/src/main/java/org/codroid/interfaces/Attachment.java
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.interfaces;
 
 import org.codroid.interfaces.env.AddonEnv;

--- a/interfaces/src/main/java/org/codroid/interfaces/addon/Addon.java
+++ b/interfaces/src/main/java/org/codroid/interfaces/addon/Addon.java
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.interfaces.addon;
 
 import org.codroid.interfaces.log.Loggable;

--- a/interfaces/src/main/java/org/codroid/interfaces/addon/AddonBase.java
+++ b/interfaces/src/main/java/org/codroid/interfaces/addon/AddonBase.java
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.interfaces.addon;
 
 

--- a/interfaces/src/main/java/org/codroid/interfaces/addon/AddonDescription.java
+++ b/interfaces/src/main/java/org/codroid/interfaces/addon/AddonDescription.java
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.interfaces.addon;
 
 import androidx.annotation.NonNull;

--- a/interfaces/src/main/java/org/codroid/interfaces/addon/AddonDexClassLoader.java
+++ b/interfaces/src/main/java/org/codroid/interfaces/addon/AddonDexClassLoader.java
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.interfaces.addon;
 
 import org.codroid.interfaces.utils.PathUtils;

--- a/interfaces/src/main/java/org/codroid/interfaces/addon/AddonLoader.java
+++ b/interfaces/src/main/java/org/codroid/interfaces/addon/AddonLoader.java
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.interfaces.addon;
 
 import org.codroid.interfaces.appearance.ThemeBase;

--- a/interfaces/src/main/java/org/codroid/interfaces/addon/AddonManager.java
+++ b/interfaces/src/main/java/org/codroid/interfaces/addon/AddonManager.java
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.interfaces.addon;
 
 import android.content.Context;

--- a/interfaces/src/main/java/org/codroid/interfaces/addon/OptionalField.java
+++ b/interfaces/src/main/java/org/codroid/interfaces/addon/OptionalField.java
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.interfaces.addon;
 
 import java.lang.annotation.ElementType;

--- a/interfaces/src/main/java/org/codroid/interfaces/appearance/Part.java
+++ b/interfaces/src/main/java/org/codroid/interfaces/appearance/Part.java
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.interfaces.appearance;
 
 import android.graphics.Color;

--- a/interfaces/src/main/java/org/codroid/interfaces/appearance/Semantic.java
+++ b/interfaces/src/main/java/org/codroid/interfaces/appearance/Semantic.java
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.interfaces.appearance;
 
 /**

--- a/interfaces/src/main/java/org/codroid/interfaces/appearance/ThemeBase.java
+++ b/interfaces/src/main/java/org/codroid/interfaces/appearance/ThemeBase.java
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.interfaces.appearance;
 
 import org.codroid.interfaces.Attachment;

--- a/interfaces/src/main/java/org/codroid/interfaces/appearance/editor/Keyword.java
+++ b/interfaces/src/main/java/org/codroid/interfaces/appearance/editor/Keyword.java
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.interfaces.appearance.editor;
 
 import org.codroid.interfaces.appearance.parts.SemanticHighlightPart;

--- a/interfaces/src/main/java/org/codroid/interfaces/appearance/editor/Operator.java
+++ b/interfaces/src/main/java/org/codroid/interfaces/appearance/editor/Operator.java
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.interfaces.appearance.editor;
 
 import org.codroid.interfaces.appearance.parts.SemanticHighlightPart;

--- a/interfaces/src/main/java/org/codroid/interfaces/appearance/editor/SemanticTextColorSpan.java
+++ b/interfaces/src/main/java/org/codroid/interfaces/appearance/editor/SemanticTextColorSpan.java
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.interfaces.appearance.editor;
 
 import android.graphics.Color;

--- a/interfaces/src/main/java/org/codroid/interfaces/appearance/editor/TextColorSpan.java
+++ b/interfaces/src/main/java/org/codroid/interfaces/appearance/editor/TextColorSpan.java
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.interfaces.appearance.editor;
 
 import android.graphics.Color;

--- a/interfaces/src/main/java/org/codroid/interfaces/appearance/editor/WrappedSpannable.java
+++ b/interfaces/src/main/java/org/codroid/interfaces/appearance/editor/WrappedSpannable.java
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.interfaces.appearance.editor;
 
 import android.text.Spannable;

--- a/interfaces/src/main/java/org/codroid/interfaces/appearance/parts/EditorPart.java
+++ b/interfaces/src/main/java/org/codroid/interfaces/appearance/parts/EditorPart.java
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.interfaces.appearance.parts;
 
 import org.codroid.interfaces.appearance.AppearanceProperty;

--- a/interfaces/src/main/java/org/codroid/interfaces/appearance/parts/SemanticHighlightPart.java
+++ b/interfaces/src/main/java/org/codroid/interfaces/appearance/parts/SemanticHighlightPart.java
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.interfaces.appearance.parts;
 
 import org.codroid.interfaces.appearance.AppearanceProperty;

--- a/interfaces/src/main/java/org/codroid/interfaces/database/AddonDao.java
+++ b/interfaces/src/main/java/org/codroid/interfaces/database/AddonDao.java
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.interfaces.database;
 
 import androidx.room.Dao;

--- a/interfaces/src/main/java/org/codroid/interfaces/database/AddonDatabase.java
+++ b/interfaces/src/main/java/org/codroid/interfaces/database/AddonDatabase.java
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.interfaces.database;
 
 import androidx.room.Database;

--- a/interfaces/src/main/java/org/codroid/interfaces/database/AddonsEntity.java
+++ b/interfaces/src/main/java/org/codroid/interfaces/database/AddonsEntity.java
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.interfaces.database;
 
 import androidx.room.ColumnInfo;

--- a/interfaces/src/main/java/org/codroid/interfaces/env/AddonEnv.java
+++ b/interfaces/src/main/java/org/codroid/interfaces/env/AddonEnv.java
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.interfaces.env;
 
 import org.codroid.interfaces.appearance.AppearanceProperty;

--- a/interfaces/src/main/java/org/codroid/interfaces/env/CodroidEnv.java
+++ b/interfaces/src/main/java/org/codroid/interfaces/env/CodroidEnv.java
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.interfaces.env;
 
 import android.text.TextUtils;

--- a/interfaces/src/main/java/org/codroid/interfaces/env/ImageResource.java
+++ b/interfaces/src/main/java/org/codroid/interfaces/env/ImageResource.java
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.interfaces.env;
 
 import android.graphics.Bitmap;

--- a/interfaces/src/main/java/org/codroid/interfaces/env/Resource.java
+++ b/interfaces/src/main/java/org/codroid/interfaces/env/Resource.java
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.interfaces.env;
 
 import androidx.annotation.NonNull;

--- a/interfaces/src/main/java/org/codroid/interfaces/env/ResourceFactory.java
+++ b/interfaces/src/main/java/org/codroid/interfaces/env/ResourceFactory.java
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.interfaces.env;
 
 import org.codroid.interfaces.appearance.AppearanceProperty;

--- a/interfaces/src/main/java/org/codroid/interfaces/env/ResourceRaw.java
+++ b/interfaces/src/main/java/org/codroid/interfaces/env/ResourceRaw.java
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.interfaces.env;
 
 public class ResourceRaw extends Resource {

--- a/interfaces/src/main/java/org/codroid/interfaces/evnet/Event.java
+++ b/interfaces/src/main/java/org/codroid/interfaces/evnet/Event.java
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.interfaces.evnet;
 
 import org.codroid.interfaces.Attachment;

--- a/interfaces/src/main/java/org/codroid/interfaces/evnet/EventCenter.java
+++ b/interfaces/src/main/java/org/codroid/interfaces/evnet/EventCenter.java
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.interfaces.evnet;
 
 import androidx.annotation.NonNull;

--- a/interfaces/src/main/java/org/codroid/interfaces/evnet/editor/DirTreeItemLoadEvent.java
+++ b/interfaces/src/main/java/org/codroid/interfaces/evnet/editor/DirTreeItemLoadEvent.java
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.interfaces.evnet.editor;
 
 import org.codroid.interfaces.evnet.Event;

--- a/interfaces/src/main/java/org/codroid/interfaces/evnet/editor/SelectionChangedEvent.java
+++ b/interfaces/src/main/java/org/codroid/interfaces/evnet/editor/SelectionChangedEvent.java
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.interfaces.evnet.editor;
 
 import org.codroid.interfaces.appearance.editor.WrappedSpannable;

--- a/interfaces/src/main/java/org/codroid/interfaces/evnet/editor/TextChangedEvent.java
+++ b/interfaces/src/main/java/org/codroid/interfaces/evnet/editor/TextChangedEvent.java
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.interfaces.evnet.editor;
 
 import org.codroid.interfaces.appearance.editor.WrappedSpannable;

--- a/interfaces/src/main/java/org/codroid/interfaces/evnet/entities/DirTreeItemEntity.java
+++ b/interfaces/src/main/java/org/codroid/interfaces/evnet/entities/DirTreeItemEntity.java
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.interfaces.evnet.entities;
 
 import org.codroid.interfaces.env.ImageResource;

--- a/interfaces/src/main/java/org/codroid/interfaces/exceptions/AddonClassLoadException.java
+++ b/interfaces/src/main/java/org/codroid/interfaces/exceptions/AddonClassLoadException.java
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.interfaces.exceptions;
 
 import androidx.annotation.Nullable;

--- a/interfaces/src/main/java/org/codroid/interfaces/exceptions/AddonException.java
+++ b/interfaces/src/main/java/org/codroid/interfaces/exceptions/AddonException.java
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.interfaces.exceptions;
 
 

--- a/interfaces/src/main/java/org/codroid/interfaces/exceptions/AddonImportException.java
+++ b/interfaces/src/main/java/org/codroid/interfaces/exceptions/AddonImportException.java
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.interfaces.exceptions;
 
 import androidx.annotation.Nullable;

--- a/interfaces/src/main/java/org/codroid/interfaces/exceptions/AppearanceClassLoadException.java
+++ b/interfaces/src/main/java/org/codroid/interfaces/exceptions/AppearanceClassLoadException.java
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.interfaces.exceptions;
 
 public class AppearanceClassLoadException extends AddonClassLoadException {

--- a/interfaces/src/main/java/org/codroid/interfaces/exceptions/AttributeNotFoundException.java
+++ b/interfaces/src/main/java/org/codroid/interfaces/exceptions/AttributeNotFoundException.java
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.interfaces.exceptions;
 
 import androidx.annotation.Nullable;

--- a/interfaces/src/main/java/org/codroid/interfaces/exceptions/EventClassLoadException.java
+++ b/interfaces/src/main/java/org/codroid/interfaces/exceptions/EventClassLoadException.java
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.interfaces.exceptions;
 
 /**

--- a/interfaces/src/main/java/org/codroid/interfaces/exceptions/IncompleteAddonDescriptionException.java
+++ b/interfaces/src/main/java/org/codroid/interfaces/exceptions/IncompleteAddonDescriptionException.java
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.interfaces.exceptions;
 
 import androidx.annotation.Nullable;

--- a/interfaces/src/main/java/org/codroid/interfaces/exceptions/NoAddonDescriptionFoundException.java
+++ b/interfaces/src/main/java/org/codroid/interfaces/exceptions/NoAddonDescriptionFoundException.java
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.interfaces.exceptions;
 
 import androidx.annotation.Nullable;

--- a/interfaces/src/main/java/org/codroid/interfaces/exceptions/PropertyInitException.java
+++ b/interfaces/src/main/java/org/codroid/interfaces/exceptions/PropertyInitException.java
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.interfaces.exceptions;
 
 import androidx.annotation.Nullable;

--- a/interfaces/src/main/java/org/codroid/interfaces/exceptions/UnknownColorException.java
+++ b/interfaces/src/main/java/org/codroid/interfaces/exceptions/UnknownColorException.java
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.interfaces.exceptions;
 
 import androidx.annotation.Nullable;

--- a/interfaces/src/main/java/org/codroid/interfaces/log/LogStream.java
+++ b/interfaces/src/main/java/org/codroid/interfaces/log/LogStream.java
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.interfaces.log;
 
 import org.codroid.interfaces.addon.AddonManager;

--- a/interfaces/src/main/java/org/codroid/interfaces/log/LogStructure.java
+++ b/interfaces/src/main/java/org/codroid/interfaces/log/LogStructure.java
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.interfaces.log;
 
 import androidx.annotation.NonNull;

--- a/interfaces/src/main/java/org/codroid/interfaces/log/Loggable.java
+++ b/interfaces/src/main/java/org/codroid/interfaces/log/Loggable.java
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.interfaces.log;
 
 /**

--- a/interfaces/src/main/java/org/codroid/interfaces/log/Logger.java
+++ b/interfaces/src/main/java/org/codroid/interfaces/log/Logger.java
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.interfaces.log;
 
 import java.io.File;

--- a/interfaces/src/main/java/org/codroid/interfaces/log/Writing2File.java
+++ b/interfaces/src/main/java/org/codroid/interfaces/log/Writing2File.java
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.interfaces.log;
 
 import android.content.Context;

--- a/interfaces/src/main/java/org/codroid/interfaces/log/Writing2SystemOut.java
+++ b/interfaces/src/main/java/org/codroid/interfaces/log/Writing2SystemOut.java
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.interfaces.log;
 
 import android.util.Log;

--- a/interfaces/src/main/java/org/codroid/interfaces/log/WritingProcessor.java
+++ b/interfaces/src/main/java/org/codroid/interfaces/log/WritingProcessor.java
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.interfaces.log;
 
 import java.util.Queue;

--- a/interfaces/src/main/java/org/codroid/interfaces/utils/LoadSequence.java
+++ b/interfaces/src/main/java/org/codroid/interfaces/utils/LoadSequence.java
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.interfaces.utils;
 
 import java.util.ArrayList;

--- a/interfaces/src/main/java/org/codroid/interfaces/utils/PathUtils.java
+++ b/interfaces/src/main/java/org/codroid/interfaces/utils/PathUtils.java
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.interfaces.utils;
 
 import java.io.File;

--- a/interfaces/src/test/java/org/codroid/interfaces/ExampleUnitTest.java
+++ b/interfaces/src/test/java/org/codroid/interfaces/ExampleUnitTest.java
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.interfaces;
 
 import org.junit.Test;

--- a/interfaces/src/test/java/org/codroid/interfaces/PathUtilsTest.java
+++ b/interfaces/src/test/java/org/codroid/interfaces/PathUtilsTest.java
@@ -1,22 +1,3 @@
-/*
- *     Copyright (c) 2021 Zachary. All rights reserved.
- *
- *     This file is part of Codroid.
- *
- *     Codroid is free software: you can redistribute it and/or modify
- *     it under the terms of the GNU General Public License as published by
- *     the Free Software Foundation, either version 3 of the License, or
- *     (at your option) any later version.
- *
- *     Codroid is distributed in the hope that it will be useful,
- *     but WITHOUT ANY WARRANTY; without even the implied warranty of
- *     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *     GNU General Public License for more details.
- *
- *     You should have received a copy of the GNU General Public License
- *     along with Codroid.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package org.codroid.interfaces;
 
 import org.codroid.interfaces.utils.PathUtils;


### PR DESCRIPTION
So after changing the license to MIT we should remove the GPL license header this PR removes it.